### PR TITLE
AIE-32: Stabilize Hive test bootstrap for host tests

### DIFF
--- a/app/lib/services/local_storage_service.dart
+++ b/app/lib/services/local_storage_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models/shopping_list_model.dart';
 import '../models/shopping_item_model.dart';
@@ -31,6 +32,9 @@ class LocalStorageService {
   Future<void> init() async {
     try {
       await Hive.initFlutter();
+    } on MissingPluginException {
+      // Host-side tests initialize Hive manually and do not register path_provider.
+      // Ignore MissingPluginException to keep test bootstrap quiet and deterministic.
     } catch (e) {
       debugPrint('⚠️ Hive.initFlutter() failed: $e');
     }


### PR DESCRIPTION
## Summary
- treat MissingPluginException from Hive.initFlutter() as expected in host-side tests
- keep production initialization behavior intact
- remove repetitive path_provider MissingPlugin noise during test runs

## Validation
- flutter analyze
- flutter test test/services/local_storage_service_test.dart
- flutter test test/services/storage_service_test.dart
- flutter test

## Notes
- scoped change to LocalStorageService.init(); no behavior changes to storage CRUD paths