### PR TITLE
docs: align README and PRDs with current behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ flutter run
 - **Automatic Data Migration**: Seamless transition from guest to authenticated user
 - **Real-time Collaboration**: Share lists and see updates instantly
 - **Cross-Device Sync**: Access your lists from anywhere (authenticated users)
+- **Member Management**: Owners can remove members, and non-owner members can leave shared lists
 
 ### Technical
 - **Cross-platform**: iOS, Android, Web, and Desktop
@@ -103,7 +104,7 @@ flutter run
 
 ### ✅ Completed
 - Complete Flutter app with Firebase backend
-- Anonymous authentication with optional Google sign-in
+- Local-only fallback when Firebase is unavailable, with anonymous auth + optional Google sign-in when enabled
 - Real-time collaborative shopping lists with member management
 - Dual-layer storage (Hive for local, Firestore for cloud)
 - Automatic data migration on account conversion

--- a/prds/02-authentication.md
+++ b/prds/02-authentication.md
@@ -28,6 +28,10 @@
 - Guests see a clear “Sign in with Google” CTA
 - Signed-in users see profile info and “Sign out” CTA
 - Firebase-unavailable state communicates local-only mode
+- Profile screen currently uses these status labels:
+  - Avatar chip: `Guest User` or `Signed In`
+  - Sign-in card status text: `Anonymous User`, `Google Account`, or `Signed In`
+  - Global status indicator labels: `Offline`, `Guest`, `Synced`, or `Connected`
 
 ## Security
 - Guest data stays on device until upgrade

--- a/prds/03-storage-and-sync.md
+++ b/prds/03-storage-and-sync.md
@@ -13,7 +13,7 @@
 - Migration runs once per authenticated user
 - Migration copies all local lists/items to Firestore
 - Migration sets a persistent completion flag per user
-- Local data is cleared after the migration routine completes and the migration flag is set
+- Local data is cleared after the migration routine completes and the migration flag is set (even if individual list migrations fail)
 - Per-list migration failures are currently logged (best-effort behavior)
 
 ## Sync Requirements
@@ -30,4 +30,5 @@
 ## Error Handling
 - Most storage calls return boolean success/failure
 - Sharing returns `ShareResult` with user-facing error messages
+- Current implementation returns a generic share failure for most backend errors because Firebase share-layer exceptions are converted to `false` before reaching `StorageService`
 - UI surfaces failures via SnackBar or dialog

--- a/prds/06-ui-and-assets.md
+++ b/prds/06-ui-and-assets.md
@@ -21,8 +21,10 @@
 ## Sharing UI Requirements
 - Share dialog only for authenticated users
 - Contact suggestions list appears in share flow
-- Member list dialog shows roles and current-user indicators
-- Owner-only member removal actions are available in the member dialog
+- Member list dialog shows roles and current-user indicators (`You` chip/label)
+- Member list dialog includes `Invite More` CTA when sharing callbacks are wired
+- Owner-only member removal actions are available in the member dialog (owners cannot remove themselves)
+- Non-owner members can leave shared lists via the list-detail overflow menu (`Leave List`)
 
 ## Profile UI Requirements
 - Display account status (local-only, guest, Google)


### PR DESCRIPTION
## Summary
- align README collaboration/status language with shipped behavior (local-only fallback and member-management realities)
- update auth PRD with current profile/status label wording used in UI
- update storage PRD with migration and share-error semantics matching the current service pipeline
- update UI PRD for member dialog behavior and leave-list action

Author: Mira (FE)

## Validation
- inspected implementation for auth status wording, member dialog/leave-list behavior, and share/migration semantics
- reviewed docs diff for internal consistency across README + touched PRDs
- markdownlint CLI was not available in this environment (`markdownlint: command not found`)

## Follow-ups
- [AIE-43](/AIE/issues/AIE-43): preserve share error specificity through firestore/storage layers so UI can surface non-generic failures