### PR TITLE
AIE-43: Preserve share error specificity in storage pipeline

### DIFF
--- a/app/lib/services/firestore_layer.dart
+++ b/app/lib/services/firestore_layer.dart
@@ -143,9 +143,13 @@ class FirestoreLayer {
   Future<bool> shareList(String listId, String email) async {
     try {
       return await FirestoreService.shareListWithUser(listId, email);
+    } on UserNotFoundException {
+      rethrow;
+    } on UserAlreadyMemberException {
+      rethrow;
     } catch (e) {
       debugPrint('❌ Firebase share failed: $e');
-      return false;
+      rethrow;
     }
   }
 

--- a/app/lib/services/firestore_service.dart
+++ b/app/lib/services/firestore_service.dart
@@ -760,9 +760,13 @@ class FirestoreService {
       });
 
       return true;
+    } on UserNotFoundException {
+      rethrow;
+    } on UserAlreadyMemberException {
+      rethrow;
     } catch (e) {
       debugPrint('Error sharing list: $e');
-      return false;
+      rethrow;
     }
   }
 }

--- a/app/lib/services/storage_service.dart
+++ b/app/lib/services/storage_service.dart
@@ -5,6 +5,7 @@ import '../models/shopping_list_model.dart';
 import '../models/shopping_item_model.dart';
 import 'local_storage_service.dart';
 import 'firestore_layer.dart';
+import 'firestore_service.dart';
 import 'firebase_auth_service.dart';
 
 // Result class for sharing operations
@@ -189,24 +190,45 @@ class StorageService {
         return ShareResult.error('Failed to share list. Please try again.');
       }
     } catch (e) {
-      final errorString = e.toString().toLowerCase();
-
-      if (errorString.contains('not found') ||
-          errorString.contains('usernotfoundexception')) {
-        return ShareResult.error(
-          'User with email $email not found.\n\nMake sure they have signed up for the app first, then try sharing again.',
-        );
-      }
-
-      if (errorString.contains('already a member') ||
-          errorString.contains('useralreadymemberexception')) {
-        return ShareResult.error('This user is already a member of this list.');
-      }
-
-      return ShareResult.error(
-        'Unable to share list with $email.\n\nPlease make sure they have the app installed and try again.',
-      );
+      return ShareResult.error(_mapShareError(e, email));
     }
+  }
+
+  static String _mapShareError(Object error, String email) {
+    if (error is UserNotFoundException) {
+      return _userNotFoundMessage(email);
+    }
+
+    if (error is UserAlreadyMemberException) {
+      return 'This user is already a member of this list.';
+    }
+
+    final errorString = error.toString().toLowerCase();
+
+    if (errorString.contains('not found') ||
+        errorString.contains('usernotfoundexception')) {
+      return _userNotFoundMessage(email);
+    }
+
+    if (errorString.contains('already a member') ||
+        errorString.contains('useralreadymemberexception')) {
+      return 'This user is already a member of this list.';
+    }
+
+    return _genericShareFailureMessage(email);
+  }
+
+  static String _userNotFoundMessage(String email) {
+    return 'User with email $email not found.\n\nMake sure they have signed up for the app first, then try sharing again.';
+  }
+
+  static String _genericShareFailureMessage(String email) {
+    return 'Unable to share list with $email.\n\nPlease make sure they have the app installed and try again.';
+  }
+
+  @visibleForTesting
+  static String mapShareErrorForTest(Object error, String email) {
+    return _mapShareError(error, email);
   }
 
   // ==========================================

--- a/app/test/screens/list_detail/view_models/list_detail_view_model_test.dart
+++ b/app/test/screens/list_detail/view_models/list_detail_view_model_test.dart
@@ -17,9 +17,13 @@ class FakeShoppingRepository implements ShoppingRepository {
 
   final Stream<ShoppingList?> listStream;
   bool removeMemberResult = true;
+  ShareResult shareResult = ShareResult.success();
   int removeMemberCalls = 0;
+  int shareListCalls = 0;
   String? lastRemovedListId;
   String? lastRemovedUserId;
+  String? lastSharedListId;
+  String? lastSharedEmail;
 
   @override
   Stream<ShoppingList?> watchList(String id) => listStream;
@@ -75,7 +79,10 @@ class FakeShoppingRepository implements ShoppingRepository {
 
   @override
   Future<ShareResult> shareList(String listId, String email) {
-    throw UnimplementedError();
+    shareListCalls += 1;
+    lastSharedListId = listId;
+    lastSharedEmail = email;
+    return Future.value(shareResult);
   }
 
   @override
@@ -389,6 +396,98 @@ void main() {
       expect(repository.removeMemberCalls, equals(1));
       expect(repository.lastRemovedListId, listId);
       expect(repository.lastRemovedUserId, otherMember.userId);
+    });
+
+    test('shareList surfaces specific not-found message from repository', () async {
+      final owner = ListMember(
+        userId: 'member-1',
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        role: MemberRole.owner,
+        joinedAt: DateTime.now(),
+        permissions: const {
+          'read': true,
+          'write': true,
+          'delete': true,
+          'share': true,
+        },
+      );
+      final list = buildList(ownerId: owner.userId, members: [owner]);
+      repository.shareResult = ShareResult.error(
+        'User with email missing@test.com not found.\n\nMake sure they have signed up for the app first, then try sharing again.',
+      );
+
+      final authState = AuthState(
+        isGoogleUser: false,
+        isAnonymous: false,
+        isAuthenticated: true,
+        isFirebaseAvailable: false,
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        user: user,
+      );
+
+      final container = buildContainer(authState: authState);
+      addTearDown(container.dispose);
+      final viewModel = container.read(
+        listDetailViewModelProvider(listId).notifier,
+      );
+
+      await emitList(list);
+
+      final success = await viewModel.shareList('missing@test.com');
+      final error = container.read(listDetailViewModelProvider(listId)).error;
+
+      expect(success, isFalse);
+      expect(repository.shareListCalls, equals(1));
+      expect(repository.lastSharedListId, listId);
+      expect(repository.lastSharedEmail, 'missing@test.com');
+      expect(error, contains('User with email missing@test.com not found.'));
+    });
+
+    test('shareList surfaces specific already-member message from repository', () async {
+      final owner = ListMember(
+        userId: 'member-1',
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        role: MemberRole.owner,
+        joinedAt: DateTime.now(),
+        permissions: const {
+          'read': true,
+          'write': true,
+          'delete': true,
+          'share': true,
+        },
+      );
+      final list = buildList(ownerId: owner.userId, members: [owner]);
+      repository.shareResult = ShareResult.error(
+        'This user is already a member of this list.',
+      );
+
+      final authState = AuthState(
+        isGoogleUser: false,
+        isAnonymous: false,
+        isAuthenticated: true,
+        isFirebaseAvailable: false,
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        user: user,
+      );
+
+      final container = buildContainer(authState: authState);
+      addTearDown(container.dispose);
+      final viewModel = container.read(
+        listDetailViewModelProvider(listId).notifier,
+      );
+
+      await emitList(list);
+
+      final success = await viewModel.shareList('member@test.com');
+      final error = container.read(listDetailViewModelProvider(listId)).error;
+
+      expect(success, isFalse);
+      expect(repository.shareListCalls, equals(1));
+      expect(error, contains('This user is already a member of this list.'));
     });
   });
 }

--- a/app/test/services/share_error_mapping_test.dart
+++ b/app/test/services/share_error_mapping_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:baskit/services/firestore_service.dart';
+import 'package:baskit/services/storage_service.dart';
+
+void main() {
+  group('StorageService share error mapping', () {
+    test('maps UserNotFoundException to explicit not-found message', () {
+      final message = StorageService.mapShareErrorForTest(
+        UserNotFoundException('missing@test.com'),
+        'missing@test.com',
+      );
+
+      expect(message, contains('User with email missing@test.com not found.'));
+      expect(
+        message,
+        contains('Make sure they have signed up for the app first'),
+      );
+    });
+
+    test('maps UserAlreadyMemberException to explicit already-member message', () {
+      final message = StorageService.mapShareErrorForTest(
+        UserAlreadyMemberException('Existing User'),
+        'existing@test.com',
+      );
+
+      expect(message, equals('This user is already a member of this list.'));
+    });
+
+    test('maps unknown errors to generic fallback message', () {
+      final message = StorageService.mapShareErrorForTest(
+        Exception('network timeout'),
+        'fallback@test.com',
+      );
+
+      expect(message, contains('Unable to share list with fallback@test.com.'));
+      expect(message, contains('Please make sure they have the app installed'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- preserve typed share failures by rethrowing UserNotFoundException / UserAlreadyMemberException from Firestore service layers
- centralize share error mapping in StorageService so known failures stay specific and unknown failures still use generic fallback
- add regression coverage for service-layer mapping and list-detail view model share error messaging

## Testing
- flutter test app/test/services/share_error_mapping_test.dart app/test/screens/list_detail/view_models/list_detail_view_model_test.dart (blocked in this runtime: /opt/flutter/bin/cache/engine.stamp permission denied)

## Related
- [AIE-43](/AIE/issues/AIE-43)