### PR TITLE
AIE-40: fix list detail lifecycle and UI correctness follow-ups

### DIFF
--- a/app/lib/models/shopping_list_model.dart
+++ b/app/lib/models/shopping_list_model.dart
@@ -111,7 +111,8 @@ class ShoppingList {
   /// Get count of shared members (excluding the owner)
   /// This is used for display purposes to show "Shared with X people"
   int get sharedMemberCount {
-    return memberCount - 1; // Exclude owner
+    final count = memberCount - 1; // Exclude owner
+    return count < 0 ? 0 : count;
   }
 
   /// Get list of shared members (excluding the owner)

--- a/app/lib/screens/list_detail/view_models/list_detail_view_model.dart
+++ b/app/lib/screens/list_detail/view_models/list_detail_view_model.dart
@@ -88,8 +88,9 @@ class ListDetailViewModel extends Notifier<ListDetailState> {
   ListDetailViewModel(this.listId);
 
   final String listId;
-  late final ShoppingRepository _repository;
+  late ShoppingRepository _repository;
   final Uuid _uuid = const Uuid();
+  StreamSubscription<ShoppingList?>? _listSubscription;
 
   @override
   ListDetailState build() {
@@ -97,6 +98,8 @@ class ListDetailViewModel extends Notifier<ListDetailState> {
 
     // Clean up resources when disposing
     ref.onDispose(() {
+      _listSubscription?.cancel();
+      _listSubscription = null;
       _repository.disposeListStream(listId);
     });
 
@@ -110,8 +113,9 @@ class ListDetailViewModel extends Notifier<ListDetailState> {
 
   // Initialize the list stream for real-time updates
   void _initializeListStream() {
+    _listSubscription?.cancel();
     final listStream = _repository.watchList(listId);
-    listStream.listen(
+    _listSubscription = listStream.listen(
       (list) {
         if (list != null) {
           state = ListDetailState.loaded(list);

--- a/app/lib/screens/lists/list_form_screen.dart
+++ b/app/lib/screens/lists/list_form_screen.dart
@@ -54,6 +54,7 @@ class _ListFormScreenState extends ConsumerState<ListFormScreen> {
     }
 
     final viewModel = ref.read(listFormViewModelProvider.notifier);
+    final submittedListName = _nameController.text.trim();
     final bool success;
 
     // Determine operation based on existing list
@@ -65,11 +66,10 @@ class _ListFormScreenState extends ConsumerState<ListFormScreen> {
 
     if (success && mounted) {
       // Show success message
-      final listName = ref.read(listFormViewModelProvider).name;
-      final message =
-          widget.existingList != null
-              ? 'List "$listName" updated successfully!'
-              : 'List "$listName" created successfully!';
+      final listName = submittedListName;
+      final message = widget.existingList != null
+          ? 'List "$listName" updated successfully!'
+          : 'List "$listName" created successfully!';
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -117,14 +117,13 @@ class _ListFormScreenState extends ConsumerState<ListFormScreen> {
         actions: [
           TextButton(
             onPressed: state.isLoading ? null : _handleSubmit,
-            child:
-                state.isLoading
-                    ? const SizedBox(
-                      width: 16,
-                      height: 16,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    )
-                    : Text(actionText),
+            child: state.isLoading
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : Text(actionText),
           ),
         ],
       ),

--- a/app/test/models/shopping_list_model_test.dart
+++ b/app/test/models/shopping_list_model_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:baskit/models/list_member_model.dart';
+import 'package:baskit/models/shopping_list_model.dart';
+
+void main() {
+  group('ShoppingList.sharedMemberCount', () {
+    test('clamps at zero for list with no members', () {
+      final list = ShoppingList(
+        id: 'list-1',
+        name: 'Groceries',
+        description: 'weekly',
+        color: '#FFFFFF',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        members: const [],
+      );
+
+      expect(list.sharedMemberCount, equals(0));
+    });
+
+    test('returns zero when only owner exists', () {
+      final owner = ListMember(
+        userId: 'owner-1',
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        role: MemberRole.owner,
+        joinedAt: DateTime.now(),
+        permissions: const {'read': true, 'write': true, 'share': true},
+      );
+      final list = ShoppingList(
+        id: 'list-2',
+        name: 'Groceries',
+        description: 'weekly',
+        color: '#FFFFFF',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        ownerId: owner.userId,
+        members: [owner],
+      );
+
+      expect(list.sharedMemberCount, equals(0));
+    });
+
+    test('returns count excluding owner for shared lists', () {
+      final owner = ListMember(
+        userId: 'owner-1',
+        displayName: 'Owner',
+        email: 'owner@test.com',
+        role: MemberRole.owner,
+        joinedAt: DateTime.now(),
+        permissions: const {'read': true, 'write': true, 'share': true},
+      );
+      final member = ListMember(
+        userId: 'member-1',
+        displayName: 'Member',
+        email: 'member@test.com',
+        role: MemberRole.member,
+        joinedAt: DateTime.now(),
+        permissions: const {'read': true, 'write': true},
+      );
+      final list = ShoppingList(
+        id: 'list-3',
+        name: 'Groceries',
+        description: 'weekly',
+        color: '#FFFFFF',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        ownerId: owner.userId,
+        members: [owner, member],
+      );
+
+      expect(list.sharedMemberCount, equals(1));
+    });
+  });
+}

--- a/app/test/screens/list_detail/view_models/list_detail_view_model_test.dart
+++ b/app/test/screens/list_detail/view_models/list_detail_view_model_test.dart
@@ -16,13 +16,18 @@ class FakeShoppingRepository implements ShoppingRepository {
   FakeShoppingRepository(this.listStream);
 
   final Stream<ShoppingList?> listStream;
+  int watchListCalls = 0;
+  int disposeListStreamCalls = 0;
   bool removeMemberResult = true;
   int removeMemberCalls = 0;
   String? lastRemovedListId;
   String? lastRemovedUserId;
 
   @override
-  Stream<ShoppingList?> watchList(String id) => listStream;
+  Stream<ShoppingList?> watchList(String id) {
+    watchListCalls += 1;
+    return listStream;
+  }
 
   @override
   Future<bool> removeMember(String listId, String userId) async {
@@ -33,7 +38,9 @@ class FakeShoppingRepository implements ShoppingRepository {
   }
 
   @override
-  void disposeListStream(String id) {}
+  void disposeListStream(String id) {
+    disposeListStreamCalls += 1;
+  }
 
   @override
   Future<bool> addItem(String listId, ShoppingItem item) {
@@ -124,6 +131,87 @@ class FakeAuthViewModel extends AuthViewModel {
 }
 
 void main() {
+  group('ListDetailViewModel lifecycle', () {
+    const listId = 'list-lifecycle';
+    late StreamController<ShoppingList?> listController;
+    late FakeShoppingRepository repository;
+    late TestUser user;
+    late AuthState authState;
+    late int activeListeners;
+
+    setUp(() {
+      activeListeners = 0;
+      listController = StreamController<ShoppingList?>.broadcast(
+        onListen: () => activeListeners += 1,
+        onCancel: () => activeListeners -= 1,
+      );
+      repository = FakeShoppingRepository(listController.stream);
+      user = TestUser('member-1');
+      authState = AuthState(
+        isGoogleUser: false,
+        isAnonymous: false,
+        isAuthenticated: true,
+        isFirebaseAvailable: false,
+        displayName: 'Member',
+        email: 'member@test.com',
+        user: user,
+      );
+    });
+
+    tearDown(() async {
+      await listController.close();
+    });
+
+    ProviderContainer buildContainer() {
+      return ProviderContainer(
+        overrides: [
+          shoppingRepositoryProvider.overrideWithValue(repository),
+          authViewModelProvider.overrideWith(
+            () => FakeAuthViewModel(authState),
+          ),
+        ],
+      );
+    }
+
+    test('cancels watchList subscription on dispose', () async {
+      final container = buildContainer();
+      container.read(listDetailViewModelProvider(listId));
+
+      await Future<void>.delayed(Duration.zero);
+      expect(repository.watchListCalls, equals(1));
+      expect(activeListeners, equals(1));
+
+      container.dispose();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(activeListeners, equals(0));
+      expect(repository.disposeListStreamCalls, equals(1));
+    });
+
+    test(
+      'keeps single active watchList subscription across rebuilds',
+      () async {
+        final container = buildContainer();
+
+        container.read(listDetailViewModelProvider(listId));
+        await Future<void>.delayed(Duration.zero);
+        expect(repository.watchListCalls, equals(1));
+        expect(activeListeners, equals(1));
+
+        container.invalidate(listDetailViewModelProvider(listId));
+        container.read(listDetailViewModelProvider(listId));
+        await Future<void>.delayed(Duration.zero);
+
+        expect(repository.watchListCalls, equals(2));
+        expect(activeListeners, equals(1));
+
+        container.dispose();
+        await Future<void>.delayed(Duration.zero);
+        expect(activeListeners, equals(0));
+      },
+    );
+  });
+
   group('ListDetailViewModel Leave List Tests', () {
     const listId = 'list-123';
     late FakeShoppingRepository repository;

--- a/app/test/screens/lists/list_form_screen_test.dart
+++ b/app/test/screens/lists/list_form_screen_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:baskit/screens/lists/list_form_screen.dart';
+import 'package:baskit/screens/lists/view_models/list_form_view_model.dart';
+
+class _FakeListFormViewModel extends ListFormViewModel {
+  @override
+  ListFormState build() => const ListFormState.initial();
+
+  @override
+  Future<bool> createList() async {
+    // Mirrors production success path where create resets form state.
+    state = const ListFormState.initial();
+    return true;
+  }
+}
+
+void main() {
+  testWidgets('create success snackbar uses submitted list name', (
+    tester,
+  ) async {
+    final binding = TestWidgetsFlutterBinding.ensureInitialized();
+    await binding.setSurfaceSize(const Size(1200, 1400));
+    addTearDown(() => binding.setSurfaceSize(null));
+
+    final scaffoldMessengerKey = GlobalKey<ScaffoldMessengerState>();
+    final router = GoRouter(
+      initialLocation: '/form',
+      routes: [
+        GoRoute(
+          path: '/form',
+          builder: (context, state) => const ListFormScreen(),
+        ),
+        GoRoute(
+          path: '/lists',
+          builder:
+              (context, state) =>
+                  const Scaffold(body: Center(child: Text('Lists Page'))),
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          listFormViewModelProvider.overrideWith(
+            () => _FakeListFormViewModel(),
+          ),
+        ],
+        child: MaterialApp.router(
+          scaffoldMessengerKey: scaffoldMessengerKey,
+          routerConfig: router,
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextFormField).first, 'Weekend Shop');
+    await tester.tap(find.text('Create'));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.text('List "Weekend Shop" created successfully!'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- cancel/replace list-detail `watchList` subscriptions and cancel on provider dispose to avoid leaked listeners
- clamp `ShoppingList.sharedMemberCount` at zero for local/edge lists
- preserve submitted list name for create success snackbar after form state reset
- add focused tests for lifecycle subscription behavior, shared-member count clamping, and create-list success snackbar text

## Validation
- `flutter analyze`
- `flutter test test/screens/list_detail/view_models/list_detail_view_model_test.dart test/models/shopping_list_model_test.dart test/screens/lists/list_form_screen_test.dart`

## Risk
- Low: scoped to list-detail/list-form state handling and targeted test coverage added