### PR TITLE
AIE-39: storage migration and Firestore correctness fixes

### DIFF
--- a/app/lib/services/firestore_layer.dart
+++ b/app/lib/services/firestore_layer.dart
@@ -8,6 +8,11 @@ import 'firestore_service.dart';
 /// Handles all Firebase operations for authenticated users
 class FirestoreLayer {
   static FirestoreLayer? _instance;
+  static Future<bool> Function(ShoppingList list)? _createListOverrideForTest;
+  static Future<bool> Function(ShoppingList list)? _updateListOverrideForTest;
+  static Future<bool> Function(String id)? _deleteListOverrideForTest;
+  static Future<bool> Function(String listId, String email)?
+  _shareListOverrideForTest;
 
   FirestoreLayer._();
 
@@ -22,6 +27,11 @@ class FirestoreLayer {
 
   /// Create a new shopping list
   Future<bool> createList(ShoppingList list) async {
+    final override = _createListOverrideForTest;
+    if (override != null) {
+      return override(list);
+    }
+
     try {
       final firebaseId = await FirestoreService.createList(list);
       return firebaseId != null;
@@ -33,14 +43,18 @@ class FirestoreLayer {
 
   /// Update an existing shopping list
   Future<bool> updateList(ShoppingList list) async {
+    final override = _updateListOverrideForTest;
+    if (override != null) {
+      return override(list);
+    }
+
     try {
-      await FirestoreService.updateList(
+      return await FirestoreService.updateList(
         list.id,
         name: list.name,
         description: list.description,
         color: list.color,
       );
-      return true;
     } catch (e) {
       debugPrint('❌ Firebase update failed: $e');
       return false;
@@ -49,9 +63,13 @@ class FirestoreLayer {
 
   /// Delete a shopping list
   Future<bool> deleteList(String id) async {
+    final override = _deleteListOverrideForTest;
+    if (override != null) {
+      return override(id);
+    }
+
     try {
-      await FirestoreService.deleteList(id);
-      return true;
+      return await FirestoreService.deleteList(id);
     } catch (e) {
       debugPrint('❌ Firebase delete failed: $e');
       return false;
@@ -141,11 +159,16 @@ class FirestoreLayer {
 
   /// Share a list with another user by email
   Future<bool> shareList(String listId, String email) async {
+    final override = _shareListOverrideForTest;
+    if (override != null) {
+      return override(listId, email);
+    }
+
     try {
       return await FirestoreService.shareListWithUser(listId, email);
     } catch (e) {
       debugPrint('❌ Firebase share failed: $e');
-      return false;
+      rethrow;
     }
   }
 
@@ -183,5 +206,41 @@ class FirestoreLayer {
   void disposeListStream(String listId) {
     // Firebase streams are managed by the Firebase SDK
     // This method exists for interface consistency
+  }
+
+  @visibleForTesting
+  static void setCreateListOverrideForTest(
+    Future<bool> Function(ShoppingList list)? override,
+  ) {
+    _createListOverrideForTest = override;
+  }
+
+  @visibleForTesting
+  static void setUpdateListOverrideForTest(
+    Future<bool> Function(ShoppingList list)? override,
+  ) {
+    _updateListOverrideForTest = override;
+  }
+
+  @visibleForTesting
+  static void setDeleteListOverrideForTest(
+    Future<bool> Function(String id)? override,
+  ) {
+    _deleteListOverrideForTest = override;
+  }
+
+  @visibleForTesting
+  static void setShareListOverrideForTest(
+    Future<bool> Function(String listId, String email)? override,
+  ) {
+    _shareListOverrideForTest = override;
+  }
+
+  @visibleForTesting
+  static void resetOverridesForTest() {
+    _createListOverrideForTest = null;
+    _updateListOverrideForTest = null;
+    _deleteListOverrideForTest = null;
+    _shareListOverrideForTest = null;
   }
 }

--- a/app/lib/services/storage_service.dart
+++ b/app/lib/services/storage_service.dart
@@ -22,6 +22,7 @@ class StorageService {
   static const String _lastSyncKey = 'last_sync_timestamp';
   static const String _migrationCompleteKey = 'migration_complete_';
   static StorageService? _instance;
+  static bool? _useLocalOverrideForTest;
 
   // Service layers
   final LocalStorageService _local = LocalStorageService.instance;
@@ -35,7 +36,8 @@ class StorageService {
   }
 
   /// Check if we should use local storage (anonymous users)
-  bool get _useLocal => FirebaseAuthService.isAnonymous;
+  bool get _useLocal =>
+      _useLocalOverrideForTest ?? FirebaseAuthService.isAnonymous;
 
   /// Initialize the storage service
   Future<void> init() async {
@@ -89,7 +91,16 @@ class StorageService {
     if (_useLocal) {
       return await _local.deleteList(id);
     } else {
-      return await _firebase.deleteList(id);
+      try {
+        final success = await _firebase.deleteList(id);
+        if (success) {
+          await _updateLastSyncTime();
+        }
+        return success;
+      } catch (e) {
+        debugPrint('❌ Firebase delete failed: $e');
+        return false;
+      }
     }
   }
 
@@ -311,7 +322,7 @@ class StorageService {
 
   /// Check if migration has been completed for current user
   Future<bool> _isMigrationComplete() async {
-    if (FirebaseAuthService.isAnonymous) {
+    if (_useLocal) {
       return true; // Anonymous users don't need migration
     }
     final prefs = await SharedPreferences.getInstance();
@@ -320,7 +331,7 @@ class StorageService {
 
   /// Mark migration as complete for current user
   Future<void> _markMigrationComplete() async {
-    if (!FirebaseAuthService.isAnonymous) {
+    if (!_useLocal) {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_currentUserMigrationKey, true);
     }
@@ -328,7 +339,7 @@ class StorageService {
 
   /// Ensure migration is complete for authenticated users
   Future<void> _ensureMigrationComplete() async {
-    if (FirebaseAuthService.isAnonymous || await _isMigrationComplete()) {
+    if (_useLocal || await _isMigrationComplete()) {
       return; // No migration needed
     }
 
@@ -337,6 +348,8 @@ class StorageService {
     try {
       // Get local lists
       final localLists = await _local.getAllLists();
+
+      var allListsMigrated = true;
 
       if (localLists.isNotEmpty) {
         // Migrate each list to Firebase
@@ -347,14 +360,23 @@ class StorageService {
               debugPrint('✅ Migrated list "${list.name}" to Firebase');
             } else {
               debugPrint('❌ Failed to migrate list "${list.name}"');
+              allListsMigrated = false;
             }
           } catch (e) {
             debugPrint('❌ Error migrating list "${list.name}": $e');
+            allListsMigrated = false;
           }
         }
 
+        if (!allListsMigrated) {
+          debugPrint(
+            '⚠️ Migration incomplete: keeping local data and leaving migration pending for retry',
+          );
+          return;
+        }
+
         debugPrint(
-          '✅ Migration completed: ${localLists.length} lists processed',
+          '✅ Migration completed: ${localLists.length} lists migrated',
         );
       }
 
@@ -463,6 +485,12 @@ class StorageService {
   static void resetInstanceForTest() {
     _instance?.dispose();
     _instance = null;
+    _useLocalOverrideForTest = null;
     LocalStorageService.resetInstanceForTest();
+  }
+
+  @visibleForTesting
+  static void setUseLocalOverrideForTest(bool? value) {
+    _useLocalOverrideForTest = value;
   }
 }

--- a/app/test/services/storage_service_test.dart
+++ b/app/test/services/storage_service_test.dart
@@ -6,6 +6,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:baskit/models/list_member_model.dart';
 import 'package:baskit/models/shopping_item_model.dart';
 import 'package:baskit/models/shopping_list_model.dart';
+import 'package:baskit/services/firestore_layer.dart';
+import 'package:baskit/services/firestore_service.dart';
 import 'package:baskit/services/storage_service.dart';
 
 void main() {
@@ -147,6 +149,135 @@ void main() {
       final stored = await storageService.getListByIdLocallyForTest('list-1');
       expect(stored!.members.length, equals(1));
       expect(stored.members.first.userId, equals(owner.userId));
+    });
+  });
+
+  group('StorageService (cloud routing overrides)', () {
+    late StorageService storageService;
+
+    setUpAll(() async {
+      final tempDir = Directory.systemTemp.createTempSync('hive_storage_cloud');
+      Hive.init(tempDir.path);
+
+      if (!Hive.isAdapterRegistered(0)) {
+        Hive.registerAdapter(ShoppingListAdapter());
+      }
+      if (!Hive.isAdapterRegistered(1)) {
+        Hive.registerAdapter(ShoppingItemAdapter());
+      }
+      if (!Hive.isAdapterRegistered(4)) {
+        Hive.registerAdapter(MemberRoleAdapter());
+      }
+      if (!Hive.isAdapterRegistered(5)) {
+        Hive.registerAdapter(ListMemberAdapter());
+      }
+    });
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      StorageService.resetInstanceForTest();
+      FirestoreLayer.resetOverridesForTest();
+      StorageService.setUseLocalOverrideForTest(false);
+      storageService = StorageService.instance;
+      await storageService.init();
+    });
+
+    tearDown(() async {
+      await storageService.clearLocalDataForTest();
+      FirestoreLayer.resetOverridesForTest();
+      StorageService.resetInstanceForTest();
+
+      try {
+        if (Hive.isBoxOpen('shopping_lists')) {
+          await Hive.box('shopping_lists').clear();
+          await Hive.box('shopping_lists').close();
+        }
+      } catch (_) {}
+    });
+
+    ShoppingList buildList(String id, String name) {
+      return ShoppingList(
+        id: id,
+        name: name,
+        description: 'desc',
+        color: '#123456',
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      );
+    }
+
+    test(
+      'keeps migration pending and local data intact on partial failure',
+      () async {
+        await storageService.saveListLocallyForTest(
+          buildList('local-1', 'One'),
+        );
+        await storageService.saveListLocallyForTest(
+          buildList('local-2', 'Two'),
+        );
+
+        FirestoreLayer.setCreateListOverrideForTest((list) async {
+          return list.id != 'local-2';
+        });
+
+        final success = await storageService.createList(
+          buildList('cloud-1', 'Cloud New'),
+        );
+        expect(success, isTrue);
+
+        expect(await storageService.isMigrationCompleteForTest(), isFalse);
+        final stillLocal = await storageService.getAllListsLocallyForTest();
+        expect(
+          stillLocal.map((list) => list.id),
+          containsAll(['local-1', 'local-2']),
+        );
+
+        FirestoreLayer.setCreateListOverrideForTest((_) async => true);
+
+        final retrySuccess = await storageService.createList(
+          buildList('cloud-2', 'Cloud Retry'),
+        );
+        expect(retrySuccess, isTrue);
+        expect(await storageService.isMigrationCompleteForTest(), isTrue);
+
+        final clearedLocal = await storageService.getAllListsLocallyForTest();
+        expect(clearedLocal, isEmpty);
+      },
+    );
+
+    test('propagates Firestore update and delete boolean results', () async {
+      final list = buildList('cloud-1', 'Cloud');
+
+      FirestoreLayer.setUpdateListOverrideForTest((_) async => false);
+      expect(await storageService.updateList(list), isFalse);
+
+      FirestoreLayer.setUpdateListOverrideForTest((_) async => true);
+      expect(await storageService.updateList(list), isTrue);
+
+      FirestoreLayer.setDeleteListOverrideForTest((_) async => false);
+      expect(await storageService.deleteList('cloud-1'), isFalse);
+
+      FirestoreLayer.setDeleteListOverrideForTest((_) async => true);
+      expect(await storageService.deleteList('cloud-1'), isTrue);
+    });
+
+    test('preserves actionable share errors from Firestore layer', () async {
+      const email = 'missing@example.com';
+
+      FirestoreLayer.setShareListOverrideForTest((listId, targetEmail) async {
+        throw UserNotFoundException(email);
+      });
+      final notFound = await storageService.shareList('list-1', email);
+      expect(notFound.success, isFalse);
+      expect(notFound.errorMessage, contains('not found'));
+      expect(notFound.errorMessage, contains(email));
+
+      FirestoreLayer.setShareListOverrideForTest((listId, targetEmail) async {
+        throw UserAlreadyMemberException('Existing User');
+      });
+      final alreadyMember = await storageService.shareList('list-1', email);
+      expect(alreadyMember.success, isFalse);
+      expect(alreadyMember.errorMessage, contains('already a member'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- make migration retry-safe: if any list migration fails, keep migration incomplete and retain local data
- make `FirestoreLayer.updateList` and `FirestoreLayer.deleteList` return underlying FirestoreService booleans directly
- preserve actionable share errors by rethrowing from `FirestoreLayer.shareList` so `StorageService.shareList` can map them correctly
- add focused cloud-routing tests in `storage_service_test.dart` for migration retry behavior, update/delete result propagation, and share error mapping

## Validation
- `flutter analyze`
- `flutter test test/services/storage_service_test.dart`

## Risk
- Low to medium: changes are scoped to storage/firestore error and migration paths; covered by focused tests
