### PR TITLE
Add Baskit docs website section without changing legal URLs

### DIFF
--- a/pages/docs/architecture.html
+++ b/pages/docs/architecture.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baskit Docs - Architecture</title>
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+  <div class="site">
+    <header>
+      <h1>Baskit Documentation</h1>
+      <p>Architecture</p>
+      <div class="top-links">
+        <a href="../index.html">Legal & Support Home</a>
+        <a href="../privacy-policy.html">Privacy Policy</a>
+        <a href="../delete-account.html">Delete Account</a>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav>
+        <h2>Docs Navigation</h2>
+        <a href="index.html">Overview</a>
+        <a class="active" href="architecture.html">Architecture</a>
+        <a href="setup.html">Setup</a>
+        <a href="testing-release.html">Testing & Release</a>
+      </nav>
+
+      <main>
+        <h2>Guest-First Runtime Model</h2>
+        <p>Baskit routes storage and sync behavior based on authentication state.</p>
+
+        <h3>Mode 1: Guest</h3>
+        <ul>
+          <li>No sign-in required.</li>
+          <li>Data is stored in local Hive storage.</li>
+          <li>Works offline by default.</li>
+        </ul>
+
+        <h3>Mode 2: Authenticated</h3>
+        <ul>
+          <li>Google Sign-In with Firebase Auth.</li>
+          <li>Lists and items stored in Firestore with collaboration support.</li>
+          <li>Cross-device access and near real-time updates.</li>
+        </ul>
+
+        <h3>Migration Flow</h3>
+        <ol>
+          <li>User starts in guest mode and creates local lists.</li>
+          <li>User signs in via Google.</li>
+          <li>App migrates local state to cloud-backed storage.</li>
+          <li>Future writes route to Firestore-backed repository.</li>
+        </ol>
+
+        <h3>Key Modules</h3>
+        <ul>
+          <li><code>app/lib/services/storage_service.dart</code> - storage routing entrypoint</li>
+          <li><code>app/lib/services/local_storage_service.dart</code> - local persistence</li>
+          <li><code>app/lib/services/firestore_service.dart</code> and <code>firestore_layer.dart</code> - cloud access</li>
+          <li><code>app/lib/repositories/storage_shopping_repository.dart</code> - repository abstraction over storage mode</li>
+        </ul>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/pages/docs/docs.css
+++ b/pages/docs/docs.css
@@ -1,0 +1,147 @@
+:root {
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --text: #1a2433;
+  --muted: #5f6b7a;
+  --primary: #1f74d1;
+  --accent: #0f4f9a;
+  --border: #d9e2ef;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  color: var(--text);
+  background: radial-gradient(circle at top right, #dce9fb, var(--bg) 30%);
+}
+
+.site {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+header {
+  background: linear-gradient(135deg, #0f4f9a, #1f74d1);
+  color: #fff;
+  border-radius: 16px;
+  padding: 24px;
+}
+
+header h1 {
+  margin: 0 0 8px;
+  font-size: 30px;
+}
+
+header p {
+  margin: 0;
+  color: #e8f1ff;
+}
+
+.top-links {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.top-links a {
+  color: #fff;
+  text-decoration: none;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.layout {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: 260px minmax(0, 1fr);
+  gap: 20px;
+}
+
+nav {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px;
+  height: fit-content;
+}
+
+nav h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+nav a {
+  display: block;
+  color: var(--accent);
+  text-decoration: none;
+  padding: 8px;
+  border-radius: 8px;
+}
+
+nav a:hover,
+nav a.active {
+  background: #e8f1ff;
+}
+
+main {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 22px;
+}
+
+main h2,
+main h3 {
+  color: var(--accent);
+}
+
+main p,
+main li {
+  line-height: 1.6;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px;
+  background: #fbfdff;
+}
+
+code,
+pre {
+  background: #f1f5fb;
+  border-radius: 6px;
+}
+
+pre {
+  padding: 12px;
+  overflow-x: auto;
+  border: 1px solid var(--border);
+}
+
+footer {
+  margin-top: 24px;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+@media (max-width: 860px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/pages/docs/index.html
+++ b/pages/docs/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baskit Docs - Overview</title>
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+  <div class="site">
+    <header>
+      <h1>Baskit Documentation</h1>
+      <p>Product and operational docs for the collaborative shopping list app.</p>
+      <div class="top-links">
+        <a href="../index.html">Legal & Support Home</a>
+        <a href="../privacy-policy.html">Privacy Policy</a>
+        <a href="../delete-account.html">Delete Account</a>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav>
+        <h2>Docs Navigation</h2>
+        <a class="active" href="index.html">Overview</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="setup.html">Setup</a>
+        <a href="testing-release.html">Testing & Release</a>
+      </nav>
+
+      <main>
+        <h2>Current Product Scope</h2>
+        <p>Baskit is a guest-first shopping list app with optional account sign-in for real-time collaboration and sync.</p>
+        <ul>
+          <li>Use immediately in guest mode with no registration.</li>
+          <li>Store data locally by default, with migration to cloud after sign-in.</li>
+          <li>Share lists with granular permissions when authenticated.</li>
+          <li>Support iOS, Android, web, and desktop builds from one Flutter codebase.</li>
+        </ul>
+
+        <h3>Source of Truth</h3>
+        <p>This docs section mirrors the repository sources and should be updated in the same PR as behavior changes.</p>
+        <ul>
+          <li><code>README.md</code> for product behavior and architecture summary</li>
+          <li><code>prds/</code> for detailed requirements</li>
+          <li><code>.github/workflows/</code> for CI and deployment behavior</li>
+          <li><code>pages/privacy-policy.html</code> and <code>pages/delete-account.html</code> for legal/public guidance</li>
+        </ul>
+
+        <div class="card-grid">
+          <div class="card">
+            <h3>Architecture</h3>
+            <p>Storage routing, sign-in migration, and collaboration model.</p>
+            <p><a href="architecture.html">Open architecture docs</a></p>
+          </div>
+          <div class="card">
+            <h3>Setup</h3>
+            <p>Local prerequisites and first run steps.</p>
+            <p><a href="setup.html">Open setup docs</a></p>
+          </div>
+          <div class="card">
+            <h3>Testing & Release</h3>
+            <p>Validation and publishing paths used by CI.</p>
+            <p><a href="testing-release.html">Open release docs</a></p>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <footer>
+      Maintainer: Mira (Documentation Web Developer). Existing legal page URLs remain unchanged.
+    </footer>
+  </div>
+</body>
+</html>

--- a/pages/docs/setup.html
+++ b/pages/docs/setup.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baskit Docs - Setup</title>
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+  <div class="site">
+    <header>
+      <h1>Baskit Documentation</h1>
+      <p>Setup</p>
+      <div class="top-links">
+        <a href="../index.html">Legal & Support Home</a>
+        <a href="../privacy-policy.html">Privacy Policy</a>
+        <a href="../delete-account.html">Delete Account</a>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav>
+        <h2>Docs Navigation</h2>
+        <a href="index.html">Overview</a>
+        <a href="architecture.html">Architecture</a>
+        <a class="active" href="setup.html">Setup</a>
+        <a href="testing-release.html">Testing & Release</a>
+      </nav>
+
+      <main>
+        <h2>Local Development Setup</h2>
+
+        <h3>Prerequisites</h3>
+        <ul>
+          <li>Flutter SDK <code>3.35.3</code></li>
+          <li>Firebase project for Auth and Firestore</li>
+          <li>Android Studio and/or Xcode</li>
+        </ul>
+
+        <h3>Initial Setup</h3>
+        <pre><code>git clone &lt;repository-url&gt;
+cd baskit/app
+flutter pub get</code></pre>
+
+        <p>Then add Firebase platform files:</p>
+        <ul>
+          <li><code>app/android/app/google-services.json</code></li>
+          <li><code>app/ios/Runner/GoogleService-Info.plist</code> (if not already present in local environment)</li>
+        </ul>
+
+        <h3>Run App</h3>
+        <pre><code>cd app
+flutter run</code></pre>
+
+        <h3>Primary References</h3>
+        <ul>
+          <li><code>README.md</code> for full project context</li>
+          <li><code>prds/00-index.md</code> for required PRD reading order</li>
+        </ul>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/pages/docs/testing-release.html
+++ b/pages/docs/testing-release.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Baskit Docs - Testing and Release</title>
+  <link rel="stylesheet" href="docs.css">
+</head>
+<body>
+  <div class="site">
+    <header>
+      <h1>Baskit Documentation</h1>
+      <p>Testing and Release</p>
+      <div class="top-links">
+        <a href="../index.html">Legal & Support Home</a>
+        <a href="../privacy-policy.html">Privacy Policy</a>
+        <a href="../delete-account.html">Delete Account</a>
+      </div>
+    </header>
+
+    <div class="layout">
+      <nav>
+        <h2>Docs Navigation</h2>
+        <a href="index.html">Overview</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="setup.html">Setup</a>
+        <a class="active" href="testing-release.html">Testing & Release</a>
+      </nav>
+
+      <main>
+        <h2>Validation Commands</h2>
+        <pre><code>cd app
+flutter analyze
+flutter test
+flutter build apk --debug --target-platform android-arm64</code></pre>
+
+        <h3>CI Summary</h3>
+        <ul>
+          <li><code>.github/workflows/build-apk.yml</code> builds and tests app changes.</li>
+          <li>Release job runs on tags and creates APK + AAB artifacts.</li>
+          <li><code>.github/workflows/deploy-pages.yml</code> publishes <code>pages/</code> to GitHub Pages when <code>pages/**</code> changes.</li>
+        </ul>
+
+        <h3>Publishing Docs Updates</h3>
+        <ol>
+          <li>Edit files under <code>pages/</code>.</li>
+          <li>Open PR with summary and validation commands.</li>
+          <li>Merge to <code>main</code> to trigger Pages deployment.</li>
+          <li>Confirm legal page URLs remain stable for store compliance.</li>
+        </ol>
+
+        <h3>Public URLs That Must Stay Stable</h3>
+        <ul>
+          <li><code>/privacy-policy.html</code></li>
+          <li><code>/delete-account.html</code></li>
+        </ul>
+      </main>
+    </div>
+  </div>
+</body>
+</html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -42,7 +42,7 @@
         }
         .nav-grid {
             display: grid;
-            grid-template-columns: 1fr 1fr;
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
             gap: 20px;
             margin: 30px 0;
         }
@@ -139,6 +139,12 @@
                 <span class="nav-icon">🗑️</span>
                 <div class="nav-title">Delete Account</div>
                 <div class="nav-description">Request permanent deletion of your account and all associated data</div>
+            </a>
+
+            <a href="docs/index.html" class="nav-card">
+                <span class="nav-icon">📚</span>
+                <div class="nav-title">Documentation</div>
+                <div class="nav-description">Read product, setup, architecture, and release documentation</div>
             </a>
         </div>
 


### PR DESCRIPTION
## Summary
- add a docs section under `pages/docs/` with Overview, Architecture, Setup, and Testing/Release pages
- add a shared `pages/docs/docs.css` stylesheet for consistent navigation and readability
- update `pages/index.html` to link to docs while keeping existing legal page paths unchanged (`privacy-policy.html`, `delete-account.html`)

## Validation
- `python3 -m http.server 8016 -d pages` (smoke test)
- checked HTTP 200 for:
  - `/index.html`
  - `/privacy-policy.html`
  - `/delete-account.html`
  - `/docs/index.html`
  - `/docs/architecture.html`
  - `/docs/setup.html`
  - `/docs/testing-release.html`

## Follow-ups
- optional: migrate docs pages to markdown/static-site generator if future docs depth grows

Author: Mira
