### PR TITLE
Align privacy and account deletion disclosures

### DIFF
--- a/app/lib/screens/profile/widgets/about_section_widget.dart
+++ b/app/lib/screens/profile/widgets/about_section_widget.dart
@@ -1,10 +1,15 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../../constants/app_colors.dart';
 import '../../../constants/app_version.dart';
 
 /// Widget that shows the about section with dialog
 class AboutSectionWidget extends StatelessWidget {
+  static final Uri _privacyPolicyUri = Uri.parse(
+    'https://kmjayadeep.github.io/baskit/privacy-policy.html',
+  );
+
   const AboutSectionWidget({super.key});
 
   @override
@@ -82,6 +87,12 @@ class AboutSectionWidget extends StatelessWidget {
                   'Version ${AppVersion.version}',
                   style: TextStyle(color: AppColors.textMuted),
                 ),
+                const SizedBox(height: 12),
+                TextButton.icon(
+                  onPressed: () => _openPrivacyPolicy(context),
+                  icon: const Icon(Icons.privacy_tip_outlined),
+                  label: const Text('Privacy Policy'),
+                ),
               ],
             ),
             actions: [
@@ -92,5 +103,19 @@ class AboutSectionWidget extends StatelessWidget {
             ],
           ),
     );
+  }
+
+  Future<void> _openPrivacyPolicy(BuildContext context) async {
+    final messenger = ScaffoldMessenger.of(context);
+    final launched = await launchUrl(
+      _privacyPolicyUri,
+      mode: LaunchMode.externalApplication,
+    );
+
+    if (!launched) {
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Could not open privacy policy')),
+      );
+    }
   }
 }

--- a/app/linux/flutter/generated_plugin_registrant.cc
+++ b/app/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,10 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/app/linux/flutter/generated_plugins.cmake
+++ b/app/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import firebase_core
 import google_sign_in_ios
 import path_provider_foundation
 import shared_preferences_foundation
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseFirestorePlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseFirestorePlugin"))
@@ -19,4 +20,5 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -917,6 +917,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "3bb000251e55d4a209aa0e2e563309dc9bb2befea2295fd0cec1f51760aac572"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.29"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.4.1"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.5"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.5"
   uuid:
     dependency: "direct main"
     description:
@@ -1007,4 +1071,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   firebase_auth: ^6.1.1
   cloud_firestore: ^6.0.3
   google_sign_in: ^7.2.0
+  url_launcher: ^6.3.2
 
 dev_dependencies:
   flutter_test:

--- a/app/windows/flutter/generated_plugin_registrant.cc
+++ b/app/windows/flutter/generated_plugin_registrant.cc
@@ -9,6 +9,7 @@
 #include <cloud_firestore/cloud_firestore_plugin_c_api.h>
 #include <firebase_auth/firebase_auth_plugin_c_api.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   CloudFirestorePluginCApiRegisterWithRegistrar(
@@ -17,4 +18,6 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FirebaseAuthPluginCApi"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/app/windows/flutter/generated_plugins.cmake
+++ b/app/windows/flutter/generated_plugins.cmake
@@ -6,6 +6,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
   cloud_firestore
   firebase_auth
   firebase_core
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/pages/delete-account.html
+++ b/pages/delete-account.html
@@ -70,15 +70,15 @@
 
     <div class="card">
         <h2>Request Account Deletion</h2>
-        <p>We're sorry to see you go! If you'd like to delete your Baskit account and all associated data, please follow the instructions below.</p>
+        <p>If you'd like to delete your Baskit account and associated cloud data, please follow the manual request process below.</p>
         
         <div class="info-box">
             <strong>⚠️ Important:</strong> Deleting your account will permanently remove:
             <ul>
                 <li>Your profile and account information</li>
-                <li>All your shopping lists</li>
-                <li>Lists shared with you by other users</li>
-                <li>Your sharing history</li>
+                <li>Shopping lists owned by your account, unless you ask us to export or transfer them first</li>
+                <li>Your membership on lists shared with you by other users</li>
+                <li>Your sharing history and cloud account metadata</li>
             </ul>
             <em>This action cannot be undone.</em>
         </div>
@@ -101,13 +101,10 @@
         <ul>
             <li>We'll process your request within 30 days</li>
             <li>You'll receive a confirmation email when deletion is complete</li>
-            <li>All your data will be permanently removed from our servers</li>
-            <li>Any lists you created will no longer be accessible to other users</li>
+            <li>Your verified account data will be permanently removed from our servers</li>
+            <li>Lists owned by your account will be deleted unless you ask us to export or transfer them first</li>
+            <li>Your account will be removed from lists shared by other users</li>
         </ul>
-
-        <div class="info-box">
-            <strong>Alternative:</strong> You can also delete your account directly from the app by going to Settings → Account → Delete Account.
-        </div>
     </div>
 
     <div class="footer">

--- a/pages/privacy-policy.html
+++ b/pages/privacy-policy.html
@@ -207,8 +207,8 @@
 
         <h3>2.3 Technical Information</h3>
         <ul>
-            <li><strong>Device Information:</strong> App version, platform (Android/iOS), basic device specifications</li>
-            <li><strong>Usage Analytics:</strong> App crashes and performance data (anonymized)</li>
+            <li><strong>Device Information:</strong> App version and platform information needed to run and support the app</li>
+            <li><strong>Diagnostics:</strong> We do not currently use analytics or crash reporting SDKs. If this changes, this policy and the Play Store data disclosures will be updated first.</li>
             <li><strong>Local Storage:</strong> App preferences and settings stored on your device</li>
         </ul>
 
@@ -306,7 +306,6 @@
         <ul>
             <li><strong>Firebase Authentication:</strong> Manages user sign-in and account security</li>
             <li><strong>Cloud Firestore:</strong> Stores and syncs your shopping lists across devices</li>
-            <li><strong>Firebase Analytics:</strong> Provides anonymized app usage insights</li>
         </ul>
         <p>Firebase services are governed by <a href="https://policies.google.com/privacy" target="_blank">Google's Privacy Policy</a>.</p>
 
@@ -324,7 +323,7 @@
         <ul>
             <li><strong>Active Accounts:</strong> Data is retained as long as your account is active</li>
             <li><strong>Inactive Accounts:</strong> Data may be deleted after 3 years of inactivity</li>
-            <li><strong>Deleted Accounts:</strong> Data is permanently deleted within 30 days of account deletion</li>
+            <li><strong>Deleted Accounts:</strong> Account data is permanently deleted within 30 days of a verified deletion request</li>
         </ul>
 
         <h3>7.2 Local Data</h3>
@@ -335,8 +334,8 @@
 
         <h3>7.3 Shared Lists</h3>
         <ul>
-            <li>Lists you've shared remain accessible to collaborators even if you delete your account</li>
-            <li>Your contributions to shared lists may remain visible to other collaborators</li>
+            <li>When an account deletion request is processed, lists owned by that account are deleted unless you ask us to export or transfer them first</li>
+            <li>Your account is removed from lists shared by other users, but content already synced to collaborators' devices may remain in their local or offline copies</li>
         </ul>
     </section>
 
@@ -360,14 +359,13 @@
         </ul>
 
         <h3>8.3 Account Deletion</h3>
-        <p>You can delete your account in two ways:</p>
+        <p>Account deletion is handled by manual email request so we can verify the account and remove cloud data correctly.</p>
         <ul>
-            <li><strong>In-App:</strong> Go to Settings → Account → Delete Account</li>
-            <li><strong>By Email:</strong> Contact us at <a href="mailto:contact@jayadeep.me">contact@jayadeep.me</a></li>
+            <li><strong>By Email:</strong> Contact us at <a href="mailto:contact@jayadeep.me?subject=Baskit%20Account%20Deletion%20Request">contact@jayadeep.me</a> from the email address linked to your Baskit account</li>
         </ul>
 
         <div class="warning-box">
-            <strong>Account Deletion Notice:</strong> Deleting your account will permanently remove all your lists and data. This action cannot be undone. Lists shared with others may remain accessible to those collaborators.
+            <strong>Account Deletion Notice:</strong> Deleting your account permanently removes your profile, owned cloud lists, and shared-list memberships from Baskit servers within 30 days of verification. This action cannot be undone.
         </div>
     </section>
 


### PR DESCRIPTION
## Summary
- update privacy and deletion pages to document manual email-based account deletion only
- remove the stale Firebase Analytics / crash reporting disclosure
- add an in-app Privacy Policy action in the About dialog
- add url_launcher and generated plugin registrants for the policy link

## Validation
- flutter analyze
- flutter test