### PR TITLE
Align Flutter toolchain documentation with CI

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-flutter 3.35.3
+flutter 3.41.6

--- a/README.md
+++ b/README.md
@@ -11,14 +11,14 @@
 ## 🚀 Quick Start
 
 ### Prerequisites
-- Flutter SDK `3.35.3` (aligned with CI)
+- Flutter SDK `3.41.6` (aligned with CI)
 - Firebase project (for backend services)
 - Android Studio / Xcode for mobile development
 
 ### Toolchain Version
-- CI is pinned to Flutter `3.35.3` (`.github/workflows/build-apk.yml`)
-- Local development should use Flutter `3.35.3` to avoid analyzer/test drift
-- Repo pin file: `.tool-versions` (`flutter 3.35.3`) for `asdf`/`mise` users
+- CI is pinned to Flutter `3.41.6` (`.github/workflows/build-apk.yml`)
+- Local development should use Flutter `3.41.6` to avoid analyzer/test drift
+- Repo pin file: `.tool-versions` (`flutter 3.41.6`) for `asdf`/`mise` users
 - Verify your active SDK: `flutter --version`
 
 ### Installation
@@ -75,7 +75,7 @@ flutter run
 - **Transparent Switching**: `StorageService` automatically routes based on authentication state
 
 ### Tech Stack
-- **Frontend**: Flutter 3.35.3 (Dart 3.9.2)
+- **Frontend**: Flutter 3.41.6 (Dart 3.11.4)
 - **State Management**: Riverpod 3.x with modern Notifier API
 - **Local Storage**: Hive 2.x for binary storage with type adapters
 - **Backend**: Firebase (Auth, Firestore)

--- a/prds/07-development.md
+++ b/prds/07-development.md
@@ -1,8 +1,8 @@
 # Baskit PRD - Development & Operations
 
 ## Toolchain
-- Local and CI Flutter version is pinned to `3.35.3`
-- Repo pin file: `.tool-versions` (`flutter 3.35.3`)
+- Local and CI Flutter version is pinned to `3.41.6`
+- Repo pin file: `.tool-versions` (`flutter 3.41.6`)
 - All Flutter commands run from `app/`
 - Validate your SDK before running checks: `flutter --version`
 


### PR DESCRIPTION
## Summary
- update .tool-versions to Flutter 3.41.6
- align README and development PRD with the CI Flutter pin
- update documented Dart tool version to 3.11.4

## Validation
- flutter --version
- flutter analyze