### PR TITLE
Suppress debug logging in release builds

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,10 @@ import 'constants/app_colors.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  if (kReleaseMode) {
+    debugPrint = (String? message, {int? wrapWidth}) {};
+  }
 
   // Try to initialize Firebase, but don't fail if it's not configured
   bool firebaseInitialized = false;


### PR DESCRIPTION
## Summary
- disable debugPrint output when the app runs in release mode
- keep existing diagnostics available in debug/profile/test contexts
- reduce the risk of production logs containing user IDs, list names, or auth state details

## Validation
- dart format lib/main.dart
- flutter analyze
- flutter test