### PR TITLE
fix: enforce Firestore list permissions

### DIFF
--- a/app/lib/services/firestore_service.dart
+++ b/app/lib/services/firestore_service.dart
@@ -63,6 +63,65 @@ class FirestoreService {
   // Get current user ID
   static String? get _currentUserId => FirebaseAuthService.currentUser?.uid;
 
+  static bool _hasListPermissionInData(
+    Map<String, dynamic> data,
+    String userId,
+    String permission,
+  ) {
+    if (data['ownerId'] == userId) {
+      return true;
+    }
+
+    final members = data['members'] as Map<String, dynamic>? ?? {};
+    final userMember = members[userId];
+    if (userMember is! Map<String, dynamic>) {
+      return false;
+    }
+
+    if (userMember['role'] == 'owner') {
+      return true;
+    }
+
+    final permissions =
+        userMember['permissions'] as Map<String, dynamic>? ?? {};
+    return permissions[permission] == true;
+  }
+
+  static bool _canRemoveMember(
+    Map<String, dynamic> data,
+    String currentUserId,
+    String targetUserId,
+  ) {
+    if (data['ownerId'] == targetUserId) {
+      return false;
+    }
+
+    if (currentUserId == targetUserId) {
+      return true;
+    }
+
+    return data['ownerId'] == currentUserId ||
+        _hasListPermissionInData(data, currentUserId, 'manage_members');
+  }
+
+  @visibleForTesting
+  static bool hasListPermissionInDataForTest(
+    Map<String, dynamic> data,
+    String userId,
+    String permission,
+  ) {
+    return _hasListPermissionInData(data, userId, permission);
+  }
+
+  @visibleForTesting
+  static bool canRemoveMemberForTest(
+    Map<String, dynamic> data,
+    String currentUserId,
+    String targetUserId,
+  ) {
+    return _canRemoveMember(data, currentUserId, targetUserId);
+  }
+
   // Initialize user profile
   static Future<void> initializeUserProfile() async {
     if (!isFirebaseAvailable) {
@@ -347,6 +406,16 @@ class FirestoreService {
     }
 
     try {
+      final listDoc = await _listsCollection.doc(listId).get();
+      if (!listDoc.exists) {
+        return false;
+      }
+
+      final data = listDoc.data() as Map<String, dynamic>;
+      if (!_hasListPermissionInData(data, _currentUserId!, 'write')) {
+        return false;
+      }
+
       final updateData = <String, dynamic>{
         'updatedAt': FieldValue.serverTimestamp(),
       };
@@ -387,6 +456,10 @@ class FirestoreService {
         }
 
         if (!members.containsKey(userId)) {
+          return false;
+        }
+
+        if (!_canRemoveMember(data, _currentUserId!, userId)) {
           return false;
         }
 
@@ -474,9 +547,7 @@ class FirestoreService {
         return false; // User is not a member
       }
 
-      final permissions =
-          userMember['permissions'] as Map<String, dynamic>? ?? {};
-      return permissions[permission] == true;
+      return _hasListPermissionInData(data, _currentUserId!, permission);
     } catch (e) {
       debugPrint('Error checking permissions: $e');
       return false;
@@ -790,6 +861,10 @@ class FirestoreService {
 
       final listData = listDoc.data() as Map<String, dynamic>;
       final members = listData['members'] as Map<String, dynamic>? ?? {};
+
+      if (!_hasListPermissionInData(listData, _currentUserId!, 'share')) {
+        return false;
+      }
 
       if (members.containsKey(targetUserId)) {
         throw UserAlreadyMemberException(targetUserName);

--- a/app/test/services/firestore_service_permission_test.dart
+++ b/app/test/services/firestore_service_permission_test.dart
@@ -1,0 +1,89 @@
+import 'package:baskit/services/firestore_service.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FirestoreService permission helpers', () {
+    const ownerId = 'owner-1';
+    const memberId = 'member-1';
+    const limitedMemberId = 'member-2';
+
+    final listData = <String, dynamic>{
+      'ownerId': ownerId,
+      'members': {
+        ownerId: {
+          'role': 'owner',
+          'permissions': {
+            'read': false,
+            'write': false,
+            'delete': false,
+            'share': false,
+          },
+        },
+        memberId: {
+          'role': 'member',
+          'permissions': {'read': true, 'write': true, 'share': true},
+        },
+        limitedMemberId: {
+          'role': 'member',
+          'permissions': {'read': true},
+        },
+      },
+    };
+
+    test('treats list owners as having all list permissions', () {
+      expect(
+        FirestoreService.hasListPermissionInDataForTest(
+          listData,
+          ownerId,
+          'share',
+        ),
+        isTrue,
+      );
+    });
+
+    test('uses granular permissions for non-owner members', () {
+      expect(
+        FirestoreService.hasListPermissionInDataForTest(
+          listData,
+          memberId,
+          'write',
+        ),
+        isTrue,
+      );
+      expect(
+        FirestoreService.hasListPermissionInDataForTest(
+          listData,
+          limitedMemberId,
+          'write',
+        ),
+        isFalse,
+      );
+    });
+
+    test('allows members to remove themselves but not other members', () {
+      expect(
+        FirestoreService.canRemoveMemberForTest(listData, memberId, memberId),
+        isTrue,
+      );
+      expect(
+        FirestoreService.canRemoveMemberForTest(
+          listData,
+          memberId,
+          limitedMemberId,
+        ),
+        isFalse,
+      );
+    });
+
+    test('allows owners to remove members but never the owner', () {
+      expect(
+        FirestoreService.canRemoveMemberForTest(listData, ownerId, memberId),
+        isTrue,
+      );
+      expect(
+        FirestoreService.canRemoveMemberForTest(listData, ownerId, ownerId),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add shared Firestore list permission helpers
- enforce write permission for metadata updates
- enforce share permission before adding members
- restrict member removal to self-removal or owner/manage-member permission

## Tests
- flutter test test/services/firestore_service_permission_test.dart
- flutter analyze