### PR TITLE
fix: parse member Firestore timestamps

### DIFF
--- a/app/lib/models/list_member_model.dart
+++ b/app/lib/models/list_member_model.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:hive/hive.dart';
 
 part 'list_member_model.g.dart';
@@ -92,9 +93,11 @@ class ListMember {
     if (joinedAtData != null) {
       if (joinedAtData is DateTime) {
         joinedAt = joinedAtData;
+      } else if (joinedAtData is Timestamp) {
+        joinedAt = joinedAtData.toDate();
       } else if (joinedAtData.toString().isNotEmpty) {
         try {
-          // Handle Firestore Timestamp or ISO string
+          // Handle ISO strings from JSON/backward-compatible test data.
           joinedAt = DateTime.parse(joinedAtData.toString());
         } catch (e) {
           // Fallback to current time if parsing fails

--- a/app/test/models/list_member_model_test.dart
+++ b/app/test/models/list_member_model_test.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:baskit/models/list_member_model.dart';
+
+void main() {
+  group('ListMember.fromFirestore', () {
+    test('parses joinedAt from Firestore Timestamp', () {
+      final joinedAt = DateTime.utc(2024, 6, 1, 12, 30);
+
+      final member = ListMember.fromFirestore('member-1', {
+        'displayName': 'Member',
+        'email': 'member@test.com',
+        'role': 'member',
+        'joinedAt': Timestamp.fromDate(joinedAt),
+        'permissions': {'read': true, 'write': true},
+      });
+
+      expect(member.joinedAt.isAtSameMomentAs(joinedAt), isTrue);
+    });
+
+    test('continues to parse joinedAt from ISO strings', () {
+      final joinedAt = DateTime.utc(2024, 6, 1, 12, 30);
+
+      final member = ListMember.fromFirestore('member-1', {
+        'displayName': 'Member',
+        'role': 'member',
+        'joinedAt': joinedAt.toIso8601String(),
+        'permissions': {'read': true},
+      });
+
+      expect(member.joinedAt, joinedAt);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- parse Firestore Timestamp values in ListMember.fromFirestore with toDate()
- keep existing DateTime and ISO string parsing paths
- add tests for Timestamp and ISO joinedAt parsing

## Tests
- flutter test test/models/list_member_model_test.dart
- flutter analyze