### PR TITLE
refactor: simplify Firestore storage layer

### DIFF
--- a/app/lib/services/firestore_layer.dart
+++ b/app/lib/services/firestore_layer.dart
@@ -32,13 +32,8 @@ class FirestoreLayer {
       return override(list);
     }
 
-    try {
-      final firebaseId = await FirestoreService.createList(list);
-      return firebaseId != null;
-    } catch (e) {
-      debugPrint('❌ Firebase create failed: $e');
-      return false;
-    }
+    final firebaseId = await FirestoreService.createList(list);
+    return firebaseId != null;
   }
 
   /// Update an existing shopping list
@@ -48,17 +43,12 @@ class FirestoreLayer {
       return override(list);
     }
 
-    try {
-      return await FirestoreService.updateList(
-        list.id,
-        name: list.name,
-        description: list.description,
-        color: list.color,
-      );
-    } catch (e) {
-      debugPrint('❌ Firebase update failed: $e');
-      return false;
-    }
+    return await FirestoreService.updateList(
+      list.id,
+      name: list.name,
+      description: list.description,
+      color: list.color,
+    );
   }
 
   /// Delete a shopping list
@@ -68,32 +58,17 @@ class FirestoreLayer {
       return override(id);
     }
 
-    try {
-      return await FirestoreService.deleteList(id);
-    } catch (e) {
-      debugPrint('❌ Firebase delete failed: $e');
-      return false;
-    }
+    return await FirestoreService.deleteList(id);
   }
 
   /// Get all shopping lists as a stream (reactive)
   Stream<List<ShoppingList>> watchLists() {
-    try {
-      return FirestoreService.getUserLists();
-    } catch (e) {
-      debugPrint('❌ Firebase stream error: $e');
-      return Stream.value([]);
-    }
+    return FirestoreService.getUserLists();
   }
 
   /// Get a specific list as a stream (reactive)
   Stream<ShoppingList?> watchList(String id) {
-    try {
-      return FirestoreService.getListById(id);
-    } catch (e) {
-      debugPrint('❌ Firebase list stream error: $e');
-      return Stream.value(null);
-    }
+    return FirestoreService.getListById(id);
   }
 
   // ==========================================
@@ -102,13 +77,8 @@ class FirestoreLayer {
 
   /// Add an item to a shopping list
   Future<bool> addItem(String listId, ShoppingItem item) async {
-    try {
-      final firebaseItemId = await FirestoreService.addItemToList(listId, item);
-      return firebaseItemId != null;
-    } catch (e) {
-      debugPrint('❌ Firebase add item failed: $e');
-      return false;
-    }
+    final firebaseItemId = await FirestoreService.addItemToList(listId, item);
+    return firebaseItemId != null;
   }
 
   /// Update an item in a shopping list
@@ -119,38 +89,23 @@ class FirestoreLayer {
     String? quantity,
     bool? completed,
   }) async {
-    try {
-      return await FirestoreService.updateItemInList(
-        listId,
-        itemId,
-        name: name,
-        quantity: quantity,
-        completed: completed,
-      );
-    } catch (e) {
-      debugPrint('❌ Firebase update item failed: $e');
-      return false;
-    }
+    return await FirestoreService.updateItemInList(
+      listId,
+      itemId,
+      name: name,
+      quantity: quantity,
+      completed: completed,
+    );
   }
 
   /// Delete an item from a shopping list
   Future<bool> deleteItem(String listId, String itemId) async {
-    try {
-      return await FirestoreService.deleteItemFromList(listId, itemId);
-    } catch (e) {
-      debugPrint('❌ Firebase delete item failed: $e');
-      return false;
-    }
+    return await FirestoreService.deleteItemFromList(listId, itemId);
   }
 
   /// Clear all completed items from a list
   Future<bool> clearCompleted(String listId) async {
-    try {
-      return await FirestoreService.clearCompletedItems(listId);
-    } catch (e) {
-      debugPrint('❌ Firebase clear completed items failed: $e');
-      return false;
-    }
+    return await FirestoreService.clearCompletedItems(listId);
   }
 
   // ==========================================
@@ -164,16 +119,7 @@ class FirestoreLayer {
       return override(listId, email);
     }
 
-    try {
-      return await FirestoreService.shareListWithUser(listId, email);
-    } on UserNotFoundException {
-      rethrow;
-    } on UserAlreadyMemberException {
-      rethrow;
-    } catch (e) {
-      debugPrint('❌ Firebase share failed: $e');
-      rethrow;
-    }
+    return await FirestoreService.shareListWithUser(listId, email);
   }
 
   // ==========================================
@@ -182,12 +128,7 @@ class FirestoreLayer {
 
   /// Remove a member from a list
   Future<bool> removeMemberFromList(String listId, String userId) async {
-    try {
-      return await FirestoreService.removeMemberFromList(listId, userId);
-    } catch (e) {
-      debugPrint('❌ Firebase remove member failed: $e');
-      return false;
-    }
+    return await FirestoreService.removeMemberFromList(listId, userId);
   }
 
   // ==========================================

--- a/app/lib/services/storage_service.dart
+++ b/app/lib/services/storage_service.dart
@@ -54,55 +54,30 @@ class StorageService {
   Future<bool> createList(ShoppingList list) async {
     if (_useLocal) {
       return await _local.upsertList(list);
-    } else {
-      try {
-        await _ensureMigrationComplete();
-        final success = await _firebase.createList(list);
-        if (success) {
-          await _updateLastSyncTime();
-        }
-        return success;
-      } catch (e) {
-        debugPrint('❌ Firebase create failed: $e');
-        return false;
-      }
     }
+
+    return _runFirebaseWrite('create', () async {
+      await _ensureMigrationComplete();
+      return await _firebase.createList(list);
+    });
   }
 
   /// Update an existing shopping list
   Future<bool> updateList(ShoppingList list) async {
     if (_useLocal) {
       return await _local.upsertList(list);
-    } else {
-      try {
-        final success = await _firebase.updateList(list);
-        if (success) {
-          await _updateLastSyncTime();
-        }
-        return success;
-      } catch (e) {
-        debugPrint('❌ Firebase update failed: $e');
-        return false;
-      }
     }
+
+    return _runFirebaseWrite('update', () => _firebase.updateList(list));
   }
 
   /// Delete a shopping list
   Future<bool> deleteList(String id) async {
     if (_useLocal) {
       return await _local.deleteList(id);
-    } else {
-      try {
-        final success = await _firebase.deleteList(id);
-        if (success) {
-          await _updateLastSyncTime();
-        }
-        return success;
-      } catch (e) {
-        debugPrint('❌ Firebase delete failed: $e');
-        return false;
-      }
     }
+
+    return _runFirebaseWrite('delete', () => _firebase.deleteList(id));
   }
 
   /// Get all shopping lists as a stream (reactive)
@@ -252,16 +227,10 @@ class StorageService {
       return await _local.removeMemberFromList(listId, userId);
     }
 
-    try {
-      final success = await _firebase.removeMemberFromList(listId, userId);
-      if (success) {
-        await _updateLastSyncTime();
-      }
-      return success;
-    } catch (e) {
-      debugPrint('❌ Firebase remove member failed: $e');
-      return false;
-    }
+    return _runFirebaseWrite(
+      'remove member',
+      () => _firebase.removeMemberFromList(listId, userId),
+    );
   }
 
   // ==========================================
@@ -356,6 +325,22 @@ class StorageService {
     if (!_useLocal) {
       final prefs = await SharedPreferences.getInstance();
       await prefs.setBool(_currentUserMigrationKey, true);
+    }
+  }
+
+  Future<bool> _runFirebaseWrite(
+    String action,
+    Future<bool> Function() operation,
+  ) async {
+    try {
+      final success = await operation();
+      if (success) {
+        await _updateLastSyncTime();
+      }
+      return success;
+    } catch (e) {
+      debugPrint('❌ Firebase $action failed: $e');
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary
- remove duplicate try/catch wrappers from FirestoreLayer where FirestoreService already normalizes results
- add a shared StorageService helper for authenticated Firebase writes and sync timestamp updates
- keep the existing repository and storage interfaces unchanged

## Tests
- flutter test test/services/storage_service_test.dart test/repositories/storage_shopping_repository_test.dart test/services/share_error_mapping_test.dart
- flutter analyze